### PR TITLE
Winrate Ranking Criteria

### DIFF
--- a/endpoints/leaderboards.md
+++ b/endpoints/leaderboards.md
@@ -5,7 +5,7 @@ Returns leaderboard information for a particular queue.
   - for duo and quad queues/modes the individual's placement results reflect their team/grouping; solo is self-explanatory
   - will limit results to the top 500 players; we never like to expose weak/beginner players
   - players that select to be "private" will have their player_name and player_id values hidden
-  - {ranking_criteria} can be: 1: team_wins, 2: team_average_placement (shown below), 3: individual_average_kills, possibly/probably others as desired
+  - {ranking_criteria} can be: 1: team_wins, 2: team_average_placement (shown below), 3: individual_average_kills, 4. win_rate, possibly/probably others as desired
   - expect this data to be cached on an hourly basis because the query to acquire the data will be expensive; don't spam the calls
  
 ```js


### PR DESCRIPTION
Imagine the following situation:

Player A played since Early Release, played about 1000 matches and won 100 of them. Quite decent.
Player B started playing about a month ago, played 100 matches and won 90 of them. 

Statistically, Player B (90% W/R) is way better than Player A (10% W/R). Although team_wins is also a great ranking criteria to show who has the highest amount of won games, win_rate would show who actually wins most of his matches. =)